### PR TITLE
Update i18next peer dependencies 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,4 +10,4 @@ The [Phrase In-Context Editor](https://help.phrase.com/help/translate-directly-o
 
 This package is a [post processor](https://www.i18next.com/misc/creating-own-plugins#post-processor) for [i18next](https://www.i18next.com/). The main job of **i18next Phrase In-Context Editor Post Processor** is to convert every translation key into a format that is understandable by the [**Phrase In-Context Editor**](https://help.phrase.com/help/configure-in-context-editor). This allows us to gather an synchronize texts between [Phrase.com](https://phrase.com/) and your app.
 
-So, to get the [Phrase In-Context Editor](https://help.phrase.com/help/translate-directly-on-your-website) integrated with your application, you just need to install and properly include it. Let's have a look how to do that in the next chapter!
+So, to get the [Phrase In-Context Editor](https://help.phrase.com/help/translate-directly-on-your-website) integrated with your application, you just need to install and properly include it. Let's have a look how to do that in the next section!

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "release": "semantic-release"
   },
   "peerDependencies": {
-    "i18next": "^19.5.1"
+    "i18next": "^19.5.1 || ^20.6.1 || ^21.6.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^5.0.1",
@@ -37,7 +37,6 @@
     "@typescript-eslint/parser": "^2.0.0",
     "eslint": "^7.3.1",
     "eslint-config-phrase": "https://github.com/phrase/eslint-config-phrase.git",
-    "i18next": "^19.6.3",
     "jest": "^26.1.0",
     "microbundle": "^0.12.2",
     "semantic-release": "^17.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -892,7 +892,7 @@
     "@babel/plugin-transform-react-jsx-development" "^7.12.12"
     "@babel/plugin-transform-react-pure-annotations" "^7.12.1"
 
-"@babel/runtime@^7.11.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.11.0", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
   integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
@@ -6223,13 +6223,6 @@ humanize-ms@^1.2.1:
   integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
   dependencies:
     ms "^2.0.0"
-
-i18next@^19.6.3:
-  version "19.8.7"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.8.7.tgz#ef023e353974d1b1453e8b6331bd9fb7cba427df"
-  integrity sha512-ezo1gb7QO4OQ5gQCdZMUxopwQSoqpRp6whdEjm1grxMSmkGj1NJ+kYS0UQd4NnpPIVqsgqTQ2L2eqSQYQ+U3Fw==
-  dependencies:
-    "@babel/runtime" "^7.12.0"
 
 iconv-lite@0.4.24:
   version "0.4.24"


### PR DESCRIPTION
Fixes #69 

I've verified by upgrading the `basic` example manually that switching to latest v20 and v21 of `i18next` both work as expected. We should update the examples accordingly in a later PR.

Tested with both npm v7 and yarn 2 as well and the issue experienced in #69 is no longer present after this change.