### PR TITLE
fix: add workaround for docs to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "test.coverage": "yarn test --coverage",
     "lint": "eslint '**/*.ts' --ignore-pattern '**/*.d.ts'",
     "lint.fix": "yarn lint --fix",
-    "docs.dev": "vuepress dev docs",
-    "docs.build": "vuepress build docs",
+    "docs.dev": "export NODE_OPTIONS=--openssl-legacy-provider && vuepress dev docs",
+    "docs.build": "export NODE_OPTIONS=--openssl-legacy-provider && vuepress build docs",
     "release": "semantic-release"
   },
   "peerDependencies": {


### PR DESCRIPTION
The `Deploy Docs` step is failing in the pipeline when commits are merged into master with a `Error: error:0308010C:digital envelope routines::unsupported` error: https://github.com/phrase/i18next-phrase-in-context-editor-post-processor/actions/runs/5005308480/jobs/8969081776

It's reproducible when one tries to run `docs.dev` locally. 

From Webpack v5.54.0+, this should be resolved. Currently Vuepress is using Webpack v4.x:
<img width="883" alt="image" src="https://github.com/phrase/i18next-phrase-in-context-editor-post-processor/assets/18315198/412c5cce-f8cb-4e9c-9167-6bc50dda798e">

We would have to see if upgrading to Vuepress v2 (along with its plugins) would resolve the issue or look into another docs generator, but this is a quickfix/workaround for now, in order for `docs.dev` and `docs.build` to run properly. 