### PR TITLE
Update peer dependency to support i18next to prevent warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "release": "semantic-release"
   },
   "peerDependencies": {
-    "i18next": "^19.5.1 || ^20.6.1 || ^21.6.0"
+    "i18next": "^19.5.1 || ^20.6.1 || ^21.6.0 || ^22.0.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "i18next-phrase-in-context-editor-post-processor",
   "description": "Plugin for i18next that paires well with Phrase In-Context Editor",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "source": "index.ts",
   "main": "dist/i18next-phrase-in-context-editor-post-processor.js",
   "unpkg": "dist/i18next-phrase-in-context-editor-post-processor.umd.js",


### PR DESCRIPTION
As seen in the image i would like to update the peer dependencies to prevent errors when using npm without --legacy-peer-deps or to prevent warnings in general when using i18next@22 


![Screenshot 2023-05-24 at 16 13 22](https://github.com/phrase/i18next-phrase-in-context-editor-post-processor/assets/115218327/029bcaf8-fa67-44d6-be6b-3ecb19bb3964)
