### PR TITLE
docs: add accountId to setup instructions

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -67,7 +67,8 @@ i18next
     .use(i18nextXHRBackend)
     .use(new PhraseInContextEditorPostProcessor({
         phraseEnabled: true,
-        projectId: '<YOUR_PHRASE_PROJECT_ID>'
+        projectId: '<YOUR_PHRASE_PROJECT_ID>' // Project ID is found in project settings.
+        accountId: '<YOUR_PHRASE_ACCOUNT_ID>' // Account ID is found in Strings organization settings.
     }))
     .init({
         fallbackLng: 'en',
@@ -93,6 +94,7 @@ i18n
     .use(new PhraseInContextEditorPostProcessor({
         phraseEnabled: true,
         projectId: '<YOUR_PROJECT_ID>',
+        accountId: '<YOUR_ACCOUNT_ID>',
         useOldICE: true,
     }))
 ```


### PR DESCRIPTION
# What this PR does:

This PR updates the [Getting started page](https://phrase.github.io/i18next-phrase-in-context-editor-post-processor/guide/#usage) to include the `accountId` parameter when initializing `PhraseInContextEditorPostProcessor`.

# Why is this needed?
According to the [Phrase docs](https://support.phrase.com/hc/en-us/articles/5784095916188-In-Context-Editor-Strings), we need to add `accountId` to make the In-context editor work.
