### PR TITLE
chore: Add Dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'yarn'
+    # this will ensure that dependabot will only scan the packages in the root directory
+    # omitting the packages in the /examples directory
+    directory: '/'


### PR DESCRIPTION
Dependabot scans the entire codebase. 
We do not want it to create PRs and security alerts for `/examples/*` sub-repositories and their packages.

- Added configuration file to disable Dependabot on nested directories.
(see https://github.com/dependabot/dependabot-core/issues/4364#issuecomment-2263221410)