### PR TITLE
chore: Fix Dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 
 updates:
-  - package-ecosystem: 'yarn'
+  - package-ecosystem: 'npm'
     # this will ensure that dependabot will only scan the packages in the root directory
     # omitting the packages in the /examples directory
     directory: '/'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
Fixes issues:
```
The property '#/updates/0' did not contain a required property of 'schedule'
The property '#/updates/0/package-ecosystem' value "yarn" did not match one of the following values: npm, bundler, composer, devcontainers, maven, mix, cargo, gradle, nuget, gomod, docker, elm, gitsubmodule, github-actions, pip, terraform, pub, swift
```