### PR TITLE
feat(STRINGS-221): Extend `PhraseConfig` type with `hidingClasses` field

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -67,8 +67,8 @@ projectId: string;
 branch: string;
 ajaxObserver: boolean;
 debugMode: boolean;
-prefix: string = '{{__';
-suffix: string = '__}}';
+prefix: string; // default: '{{__'
+suffix: string; // default: '__}}'
 autoLowercase: boolean;
 forceLocale: boolean;
 loginDialogMessage: string;
@@ -84,5 +84,7 @@ sso: {
     provider: string;
     identifier: string;
 };
-fullReparse: boolean = true;
+fullReparse: boolean // default: true;
+origin: string;
+hidingClasses: string[]; // default: ['hidden', 'visuallyhidden', 'invisible'];
 ```

--- a/src/phrase-config.type.ts
+++ b/src/phrase-config.type.ts
@@ -35,4 +35,5 @@ export type PhraseConfig = {
     };
     fullReparse: boolean;
     origin: string;
+    hidingClasses?: string[];
 };


### PR DESCRIPTION
Extended `PhraseConfig` type with `hidingClasses` field.
By default the Phrase ICE uses `['hidden', 'visuallyhidden', 'invisible']`. 
All elements on the page that contain listed classes won't be taken into account by ICE. 
The user may provide `hidingClasses` array to override the defaults.