### PR TITLE
fix(SCM-659): Add new option for toggling off sentry and mixpanel

### DIFF
--- a/src/phrase-config.type.ts
+++ b/src/phrase-config.type.ts
@@ -21,6 +21,7 @@ export type PhraseConfig = {
     autoLowercase: boolean;
     forceLocale: boolean;
     loginDialogMessage: string;
+    telemetryEnabled: boolean;
     datacenter: 'eu' | 'us';
     autoLogin: {
         perform: boolean;

--- a/src/phrase.ts
+++ b/src/phrase.ts
@@ -21,7 +21,7 @@ export default class PhraseInContextEditorPostProcessor {
         if (this.config.useOldICE) {
             return `https://phrase.com/assets/in-context-editor/2.0/app.js?${new Date().getTime()}`;
         } else {
-            return 'https://cdn.phrase.com/strings/plugins/editor/latest_test/ice/index.js';
+            return 'https://cdn.phrase.com/strings/plugins/editor/latest/ice/index.js';
         }
     }
 

--- a/src/phrase.ts
+++ b/src/phrase.ts
@@ -21,7 +21,7 @@ export default class PhraseInContextEditorPostProcessor {
         if (this.config.useOldICE) {
             return `https://phrase.com/assets/in-context-editor/2.0/app.js?${new Date().getTime()}`;
         } else {
-            return 'https://cdn.phrase.com/strings/plugins/editor/latest/ice/index.js';
+            return 'https://cdn.phrase.com/strings/plugins/editor/latest_test/ice/index.js';
         }
     }
 


### PR DESCRIPTION
Set `telemetryEnabled: false` to disable sentry and mixpanel tracking.

https://phrase.atlassian.net/browse/SCM-659