### PR TITLE
chore: Use older node for doc deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,7 +13,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 18
       - name: Install and Build 🔧
         run: |
           yarn install


### PR DESCRIPTION
Fix https://github.com/phrase/i18next-phrase-in-context-editor-post-processor/actions/runs/21292359422/job/61289080432